### PR TITLE
Survive initial exception

### DIFF
--- a/server.rb
+++ b/server.rb
@@ -111,9 +111,13 @@ module DS9
         sock.setsockopt Socket::IPPROTO_TCP, Socket::TCP_NODELAY, 1
         puts "OMG"
 
-        session = MySession.new sock
-        session.submit_settings SETTINGS
-        session.run
+        begin
+          session = MySession.new sock
+          session.submit_settings SETTINGS
+          session.run
+        rescue Exception => e
+          puts e
+        end
       end
     end
   end


### PR DESCRIPTION
This isn't very satisfying, but it did get it working (it renders "hello world!") in Chrome on my machine.

Based on a Wireshark capture and what Chrome displays in `net-internals`, even after you've trusted an invalid certificate, Chrome will connect twice, abandoning the first connection after it realizes the certificate is invalid. Since the server crashes on this first EOF:

```
$ bundle exec ruby server.rb public.pem private.pem                                                                                                                                                   
OMG
{:recv_event=>"EOF"}
server.rb:97:in `receive': Error: EOF (DS9::Exception)
from server.rb:97:in `run'
from server.rb:116:in `block in run'
from server.rb:109:in `loop'
from server.rb:109:in `run'
from server.rb:123:in `<main>'
```

…the second connection fails with a connection refused message.

You can see this in more detail by going to [chrome://net-internals/#events](chrome://net-internals/#events) and searching for `8080 type:socket`, attempting the connection in another tab, and then clicking on the entries to view the log.

It wasn't as helpful, but on Mac OS I have trouble with Wireshark's built-in capture tool, so I do:

```
sudo tcpdump -Xvv -w wat.pcap -i any port 8080
```

Then I [configure Wireshark with the private key](https://wiki.wireshark.org/SSL), let it crash once (I have no idea why), and then open the capture file. You can filter only the parsed TLS packets by putting `ssl` in the filter bar.

I didn't try Firefox, so I don't know what's going on there. I sure hope this helps!
